### PR TITLE
Исправления в методах базового класса миграций AbstractIBlockMigration

### DIFF
--- a/Tools/Data/Migration/Bitrix/AbstractIBlockMigration.php
+++ b/Tools/Data/Migration/Bitrix/AbstractIBlockMigration.php
@@ -96,11 +96,10 @@ abstract class AbstractIBlockMigration implements MigrationInterface
 	 */
 	protected function createIBlock(array $arFields)
 	{
-		if ($id = $this->iBlockGateway->Add($arFields)) {
-			$this->iblockId = $id;
+		if (!$id = $this->iBlockGateway->Add($arFields)) {
+			throw new MigrationException($this->iBlockGateway->LAST_ERROR);
 		}
-
-		throw new MigrationException($this->iBlockGateway->LAST_ERROR);
+		$this->iblockId = $id;
 	}
 
 	/**

--- a/Tools/Data/Migration/Bitrix/AbstractIBlockMigration.php
+++ b/Tools/Data/Migration/Bitrix/AbstractIBlockMigration.php
@@ -106,13 +106,19 @@ abstract class AbstractIBlockMigration implements MigrationInterface
 	 * @param int $id
 	 * @param array $arFields
 	 *
+	 * @return bool
+	 *
 	 * @throws MigrationException
 	 */
 	protected function updateIBlock($id, array $arFields)
 	{
-		if (!$this->iBlockGateway->Update($id, $arFields)) {
-			throw new MigrationException($this->iBlockGateway->LAST_ERROR);
+		if ($this->iBlockGateway->Update($id, $arFields)) {
+			$this->iblockId = $id;
+
+			return true;
 		}
+
+		throw new MigrationException($this->iBlockGateway->LAST_ERROR);
 	}
 
 	/**

--- a/Tools/Data/Migration/Bitrix/AbstractIBlockMigration.php
+++ b/Tools/Data/Migration/Bitrix/AbstractIBlockMigration.php
@@ -110,11 +110,9 @@ abstract class AbstractIBlockMigration implements MigrationInterface
 	 */
 	protected function updateIBlock($id, array $arFields)
 	{
-		if ($id = $this->iBlockGateway->Update($id, $arFields)) {
-			$this->iblockId = $id;
+		if (!$this->iBlockGateway->Update($id, $arFields)) {
+			throw new MigrationException($this->iBlockGateway->LAST_ERROR);
 		}
-
-		throw new MigrationException($this->iBlockGateway->LAST_ERROR);
 	}
 
 	/**


### PR DESCRIPTION
В методе создания инфоблока (createIBlock), исправлен вызов исключения при успешном создании инфоблока.
В методе обновления инфоблока (updateIBlock), исправлено:
- вызов исключения при успешном обновлении инфоблока
- не правильная обработка результатов метода CIBlock::Update. Метод возвращает true если изменение прошло успешно, при возникновении ошибки метод вернет false, id метод не возвращает.
