### PR TITLE
AbstractIBlockPropertyMigration

### DIFF
--- a/Tools/Data/Migration/Bitrix/AbstractIBlockPropertyMigration.php
+++ b/Tools/Data/Migration/Bitrix/AbstractIBlockPropertyMigration.php
@@ -22,6 +22,9 @@ abstract class AbstractIBlockPropertyMigration implements MigrationInterface
 	const LIST_TYPE_SELECT = 'L';
 	const LIST_TYPE_CHECKBOX = 'C';
 
+	const LINK_TYPE_ELEMENT = 'E';
+	const LINK_TYPE_SECTION = 'G';
+
 	/**
 	 * @var \CIBlockProperty
 	 */
@@ -202,7 +205,7 @@ abstract class AbstractIBlockPropertyMigration implements MigrationInterface
 	 *
 	 * @throws MigrationException
 	 */
-	protected function createLinkProperty($name, $code, array $arFields = array(), $iBlockId = null, $typeLink = 'E')
+	protected function createLinkProperty($name, $code, array $arFields = array(), $iBlockId = null, $typeLink = self::LINK_TYPE_ELEMENT)
 	{
 		$arFields['PROPERTY_TYPE'] = $typeLink;
 

--- a/Tools/Data/Migration/Bitrix/AbstractIBlockPropertyMigration.php
+++ b/Tools/Data/Migration/Bitrix/AbstractIBlockPropertyMigration.php
@@ -198,12 +198,13 @@ abstract class AbstractIBlockPropertyMigration implements MigrationInterface
 	 * @param string $code
 	 * @param array $arFields
 	 * @param int $iBlockId
+	 * @param string $typeLink
 	 *
 	 * @throws MigrationException
 	 */
-	protected function createLinkProperty($name, $code, array $arFields = array(), $iBlockId = null)
+	protected function createLinkProperty($name, $code, array $arFields = array(), $iBlockId = null, $typeLink = 'E')
 	{
-		$arFields['PROPERTY_TYPE'] = 'E';
+		$arFields['PROPERTY_TYPE'] = $typeLink;
 
 		if ($iBlockId) {
 			$arFields['LINK_IBLOCK_ID'] = $iBlockId;


### PR DESCRIPTION
В метод createLinkProperty добавлена возможность, создавать свойства типа привязка к разделам.
Ранее PROPERTY_TYPE был жестко указан "E", это не давало возможности создавать свойства типа привязка к разделам "G"
