### PR TITLE
IBlockElementManager 

### DIFF
--- a/Data/Bitrix/IBlockElementManager.php
+++ b/Data/Bitrix/IBlockElementManager.php
@@ -215,4 +215,14 @@ final class IBlockElementManager implements ObjectManagerInterface, SingletonInt
 			$internalException ? $internalException->GetID() : 0
 		);
 	}
+
+	/**
+	 * Вернет текст ошибки, возникшей при добавлении/обновлении элемента
+	 *
+	 * @return string
+	 */
+	public function getLastError()
+	{
+		return $this->iBEGateway->LAST_ERROR;
+	}
 }


### PR DESCRIPTION
Добавлен метод, который вернет текст ошибки при добавлении или обновлении элемента инфоблока. Хочется иметь возможность, понимать по какой причине не удалось добавить или обновить элемент.

Решил не добавлять Exception в методы add и update, а сделать отдельный метод получения текста ошибки getLastError. Т.к. IBlockElementManager активно используется, а в старом коде не предусмотрено возникновение исключения, это может привести к множеству ошибок.
